### PR TITLE
Fix/serialize geojson

### DIFF
--- a/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/IncidentResource.java
+++ b/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/IncidentResource.java
@@ -2,8 +2,10 @@ package visualization.web.resources;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.*;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+import visualization.web.resources.serializers.GeoJsonPointSerializer;
 
 /*
 Representation of an Incident
@@ -22,7 +24,7 @@ public class IncidentResource {
     @JsonProperty
     private int key;
 
-    @JsonProperty
+    @JsonSerialize(using = GeoJsonPointSerializer.class)
     private GeoJsonPoint coordinates;
 
     @JsonProperty

--- a/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/RideResource.java
+++ b/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/RideResource.java
@@ -2,8 +2,10 @@ package visualization.web.resources;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.*;
 import org.springframework.data.mongodb.core.geo.GeoJsonLineString;
+import visualization.web.resources.serializers.GeoJsonLineStringSerializer;
 
 import java.util.ArrayList;
 
@@ -21,7 +23,7 @@ public class RideResource {
     @JsonProperty
     private String rideId;
 
-    @JsonProperty
+    @JsonSerialize(using = GeoJsonLineStringSerializer.class)
     private GeoJsonLineString coordinates;
 
     @JsonProperty

--- a/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/serializers/GeoJsonLineStringSerializer.java
+++ b/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/serializers/GeoJsonLineStringSerializer.java
@@ -1,0 +1,32 @@
+package visualization.web.resources.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.springframework.data.mongodb.core.geo.GeoJsonLineString;
+import org.springframework.data.geo.Point;
+
+import java.io.IOException;
+
+public class GeoJsonLineStringSerializer extends StdSerializer<GeoJsonLineString> {
+
+    public GeoJsonLineStringSerializer() {
+        this(null);
+    }
+
+    private GeoJsonLineStringSerializer(Class<GeoJsonLineString> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(GeoJsonLineString to_serialize, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("type", to_serialize.getType());
+        jsonGenerator.writeArrayFieldStart("coordinates");
+        for (Point point:to_serialize.getCoordinates()) {
+            jsonGenerator.writeArray(new double[]{point.getX(), point.getY()}, 0, 2);
+        }
+        jsonGenerator.writeEndArray();
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/serializers/GeoJsonPointSerializer.java
+++ b/backend/SimRa-Visualization-API/src/main/java/visualization/web/resources/serializers/GeoJsonPointSerializer.java
@@ -1,0 +1,30 @@
+package visualization.web.resources.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+
+import java.io.IOException;
+
+public class GeoJsonPointSerializer extends StdSerializer<GeoJsonPoint> {
+
+    public GeoJsonPointSerializer() {
+        this(null);
+    }
+
+    private GeoJsonPointSerializer(Class<GeoJsonPoint> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(GeoJsonPoint to_serialize, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("type", to_serialize.getType());
+        jsonGenerator.writeArrayFieldStart("coordinates");
+        jsonGenerator.writeNumber(to_serialize.getX());
+        jsonGenerator.writeNumber(to_serialize.getY());
+        jsonGenerator.writeEndArray();
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/misc/mongosampleinsert.txt
+++ b/misc/mongosampleinsert.txt
@@ -2,16 +2,16 @@ use simra
 
 db.incidents.insert(
 [
-{_id: {rideId:"1", key:"0"},rideId:"1",key:0,location: {type:"Point", coordinates: [ 52.49043 , 13.23565] },ts:1567578451259},
-{_id: {rideId:"1", key:"1"},rideId:"1",key:1,location: {type:"Point", coordinates: [ 52.49043 , 13.23565] },ts:1567577189365},
-{_id: {rideId:"1", key:"2"},rideId:"1",key:2,location: {type:"Point", coordinates: [ 52.49032 , 13.23328] },ts:1567578377724},
-{_id: {rideId:"1", key:"3"},rideId:"1",key:3,location: {type:"Point", coordinates: [ 52.49047 , 13.24700] },ts:1567578307435}
+{_id: {rideId:"1", key:"0"},rideId:"1",key:0,location: {type:"Point", coordinates: [ 13.23565, 52.49043 ] },ts:1567578451259},
+{_id: {rideId:"1", key:"1"},rideId:"1",key:1,location: {type:"Point", coordinates: [ 13.23565, 52.49043 ] },ts:1567577189365},
+{_id: {rideId:"1", key:"2"},rideId:"1",key:2,location: {type:"Point", coordinates: [ 13.23328, 52.49032 ] },ts:1567578377724},
+{_id: {rideId:"1", key:"3"},rideId:"1",key:3,location: {type:"Point", coordinates: [ 13.24700, 52.49047 ] },ts:1567578307435}
 ]
 )
 
 db.rides.insert(
 {_id: "1", location: {type:"LineString", coordinates: [
-[ 52.43087,13.26155] , [ 52.43030,13.26008] , [ 52.43103,13.25930] , [ 52.24333,13.25893]
+[ 13.26155, 52.43087] , [ 13.26008, 52.43030] , [ 13.25930, 52.43103 ] , [ 13.25893, 52.24333 ]
 ] },ts:[1567575044325, 1567575081125, 1567575172884, 1567575271036]
 }
 )


### PR DESCRIPTION
Custom Jackson Serializer die LineString und Points im von GeoJson vorgeschriebenen Format zurückgeben. Zusätzlich ein kleiner Fix für die Sample Inserts für die Datenbank: das GeoJson Format ist coordinates: [lon, lat].